### PR TITLE
Fix platanus allee

### DIFF
--- a/Platanus-allee_v2.2.2_modified/baseCommand.cpp
+++ b/Platanus-allee_v2.2.2_modified/baseCommand.cpp
@@ -146,7 +146,7 @@ bool BaseCommand::parseArgs(int argc, char **argv)
 int BaseCommand::divideArgvInt(char *args) const
 {
     char *moveArgs = args;
-    for (;moveArgs != '\0'; ++moveArgs) {
+    for (;*moveArgs != '\0'; ++moveArgs) {
         if (isdigit(*moveArgs)) {
             return atoi(moveArgs);
         }

--- a/Platanus-allee_v2.2.2_modified/pairedDBG.cpp
+++ b/Platanus-allee_v2.2.2_modified/pairedDBG.cpp
@@ -26,6 +26,7 @@ with Platanus-allee; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include <queue>
 #include <array>
+#include <numeric>
 
 using std::vector;
 using std::string;


### PR DESCRIPTION
I tried to make in Platanus-allee_v2.2.2_modified/ but compile by gcc-13.2.0 failed.
Errors were:

> baseCommand.cpp: In member function 'int BaseCommand::divideArgvInt(char*) cons ':
> baseCommand.cpp:149:20: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
>   149 |     for (;moveArgs != '\0'; ++moveArgs) {
>       |           ~~~~~~~~~^~~~~~~

> pairedDBG.cpp: In member function 'void PairedDBG::getHeteroMPLinkScoreBetweenScaffold(const std::array<std::array<std::vector<ScaffoldGraph::ScaffoldPart>, 2>, 2>&, std::array<long int, 2>&)':
> pairedDBG.cpp:11413:35: error: 'accumulate' is not a member of 'std'
> 11413 |                           << std::accumulate(conflictpoints[0][0].begin(), conflictpoints[0][0].end(), 0.0) << "\t"
>       |                                   ^~~~~~~~~~
